### PR TITLE
Add relationship loading from Parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,25 @@ cargo run -- <parquet-file> <node-label> [concurrency]
 ```
 
 The application reads the Parquet file and creates nodes with the given label in the database. The optional concurrency argument controls how many rows are inserted in parallel (default is 4).
+
+## Loading relationships
+
+The crate also includes a helper to create relationships from Parquet files. Each
+row should specify the identifiers of the start and end nodes and any additional
+relationship properties.
+
+```rust
+use neo4j_parallel_rust_loader::{connect, load_parquet_relationships_parallel, Neo4jConfig};
+
+let graph = connect(&cfg).await?;
+load_parquet_relationships_parallel(
+    graph,
+    "rels.parquet",
+    "KNOWS",      // relationship type
+    "Person",     // start node label
+    "start_name", // column to match start node
+    "Person",     // end node label
+    "end_name",   // column to match end node
+    4,
+).await?;
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod loader;
 
 pub use config::Neo4jConfig;
 pub use neo4j::connect;
-pub use loader::load_parquet_parallel;
+pub use loader::{load_parquet_parallel, load_parquet_relationships_parallel};
 
 #[cfg(test)]
 mod tests {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -55,3 +55,90 @@ pub async fn load_parquet_parallel<P: AsRef<Path>>(
     }
     Ok(())
 }
+
+/// Load relationships from a Parquet file in parallel.
+///
+/// Each row must contain identifiers for the start and end nodes as well as any
+/// relationship properties. The `start_id_col` and `end_id_col` parameters
+/// specify the column names used to match existing nodes. Nodes are matched by
+/// label and property value.
+pub async fn load_parquet_relationships_parallel<P: AsRef<Path>>(
+    graph: Graph,
+    path: P,
+    rel_type: &str,
+    start_label: &str,
+    start_id_col: &str,
+    end_label: &str,
+    end_id_col: &str,
+    concurrency: usize,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let path_buf = path.as_ref().to_path_buf();
+    // Read all rows from parquet in a blocking task
+    let rows: Vec<Row> = tokio::task::spawn_blocking(move || -> Result<_, Box<dyn std::error::Error + Send + Sync>> {
+        let file = std::fs::File::open(path_buf)?;
+        let reader = SerializedFileReader::new(file)?;
+        let iter = reader.get_row_iter(None)?;
+        let mut rows = Vec::new();
+        for row in iter {
+            rows.push(row?);
+        }
+        Ok(rows)
+    })
+    .await??;
+
+    let semaphore = Arc::new(Semaphore::new(concurrency));
+    let mut tasks = FuturesUnordered::new();
+
+    for row in rows {
+        let graph = graph.clone();
+        let rel_type = rel_type.to_owned();
+        let start_label = start_label.to_owned();
+        let end_label = end_label.to_owned();
+        let start_id_col = start_id_col.to_owned();
+        let end_id_col = end_id_col.to_owned();
+        let permit = semaphore.clone().acquire_owned().await?;
+        tasks.push(tokio::spawn(async move {
+            let _permit = permit;
+            let mut props: HashMap<String, BoltType> = HashMap::new();
+            let mut start_id: Option<BoltType> = None;
+            let mut end_id: Option<BoltType> = None;
+            for (key, field) in row.get_column_iter() {
+                let json = field.to_json_value();
+                let bolt: BoltType = json.try_into()?;
+                if key == &start_id_col {
+                    start_id = Some(bolt);
+                } else if key == &end_id_col {
+                    end_id = Some(bolt);
+                } else {
+                    props.insert(key.clone(), bolt);
+                }
+            }
+            let start_val = start_id.ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("missing start id column: {}", start_id_col),
+                )
+            })?;
+            let end_val = end_id.ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("missing end id column: {}", end_id_col),
+                )
+            })?;
+            let q = query(format!(
+                "MATCH (a:{start_label} {{{start_id_col}: $start}}) \
+                 MATCH (b:{end_label} {{{end_id_col}: $end}}) \
+                 CREATE (a)-[r:{rel_type} $props]->(b)"
+            ).as_str())
+                .param("start", start_val)
+                .param("end", end_val)
+                .param("props", props);
+            graph.run(q).await
+        }));
+    }
+
+    while let Some(res) = tasks.next().await {
+        res??;
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
-use neo4j_parallel_rust_loader::{connect, load_parquet_parallel, Neo4jConfig};
+use neo4j_parallel_rust_loader::{
+    connect,
+    load_parquet_parallel,
+    load_parquet_relationships_parallel,
+    Neo4jConfig,
+};
 use std::env;
 
 #[tokio::main]
@@ -7,22 +12,101 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cfg = Neo4jConfig::from_env()?;
     let mut args = env::args();
     let _bin = args.next();
-    let path = match args.next() {
-        Some(p) => p,
+    let mode = match args.next() {
+        Some(m) => m,
         None => {
-            eprintln!("Usage: cargo run -- <path> <label> [concurrency]");
+            eprintln!(
+                "Usage:\n  cargo run -- nodes <path> <label> [concurrency]\n  cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+            );
             std::process::exit(1);
         }
     };
-    let label = match args.next() {
-        Some(l) => l,
-        None => {
-            eprintln!("Usage: cargo run -- <path> <label> [concurrency]");
-            std::process::exit(1);
-        }
-    };
-    let concurrency: usize = args.next().unwrap_or_else(|| "4".to_string()).parse().unwrap_or(4);
     let graph = connect(&cfg).await?;
-    load_parquet_parallel(graph, path, &label, concurrency).await?;
+    if mode == "nodes" {
+        let path = match args.next() {
+            Some(p) => p,
+            None => {
+                eprintln!("Usage: cargo run -- nodes <path> <label> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let label = match args.next() {
+            Some(l) => l,
+            None => {
+                eprintln!("Usage: cargo run -- nodes <path> <label> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let concurrency: usize = args
+            .next()
+            .unwrap_or_else(|| "4".to_string())
+            .parse()
+            .unwrap_or(4);
+        load_parquet_parallel(graph, path, &label, concurrency).await?;
+    } else if mode == "rels" {
+        let path = match args.next() {
+            Some(p) => p,
+            None => {
+                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let rel_type = match args.next() {
+            Some(l) => l,
+            None => {
+                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let start_label = match args.next() {
+            Some(l) => l,
+            None => {
+                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let start_col = match args.next() {
+            Some(c) => c,
+            None => {
+                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let end_label = match args.next() {
+            Some(l) => l,
+            None => {
+                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let end_col = match args.next() {
+            Some(c) => c,
+            None => {
+                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                std::process::exit(1);
+            }
+        };
+        let concurrency: usize = args
+            .next()
+            .unwrap_or_else(|| "4".to_string())
+            .parse()
+            .unwrap_or(4);
+        load_parquet_relationships_parallel(
+            graph,
+            path,
+            &rel_type,
+            &start_label,
+            &start_col,
+            &end_label,
+            &end_col,
+            concurrency,
+        )
+        .await?;
+    } else {
+        eprintln!(
+            "Usage:\n  cargo run -- nodes <path> <label> [concurrency]\n  cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+        );
+        std::process::exit(1);
+    }
     Ok(())
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,9 @@
-use neo4j_parallel_rust_loader::{load_parquet_parallel, connect, Neo4jConfig};
+use neo4j_parallel_rust_loader::{
+    load_parquet_parallel,
+    load_parquet_relationships_parallel,
+    connect,
+    Neo4jConfig,
+};
 use dotenvy::dotenv;
 use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
@@ -17,6 +22,27 @@ fn create_parquet(path: &str) -> Result<(), Box<dyn std::error::Error>> {
         vec![
             Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])),
             Arc::new(Int64Array::from(vec![30, 25, 40])),
+        ],
+    )?;
+    let file = File::create(path)?;
+    let mut writer = ArrowWriter::try_new(file, schema, None)?;
+    writer.write(&batch)?;
+    writer.close()?;
+    Ok(())
+}
+
+fn create_rel_parquet(path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("start_name", DataType::Utf8, false),
+        Field::new("end_name", DataType::Utf8, false),
+        Field::new("since", DataType::Int64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["Alice", "Bob"])),
+            Arc::new(StringArray::from(vec!["Bob", "Carol"])),
+            Arc::new(Int64Array::from(vec![2020, 2021])),
         ],
     )?;
     let file = File::create(path)?;
@@ -79,4 +105,51 @@ async fn test_loader() {
         count = row.get::<i64>("c").unwrap();
     }
     assert!(count >= 3);
+}
+
+#[tokio::test]
+async fn test_relationship_loader() {
+    dotenv().ok();
+    let cfg = match Neo4jConfig::from_env() {
+        Ok(cfg) => cfg,
+        Err(_) => {
+            eprintln!("Skipping test_relationship_loader: missing env vars");
+            return;
+        }
+    };
+    let graph = match connect(&cfg).await {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("Could not connect to database: {e}");
+            return;
+        }
+    };
+    let parquet = "tests/data/sample.parquet";
+    create_parquet(parquet).unwrap();
+    load_parquet_parallel(graph.clone(), parquet, "Person", 4).await.unwrap();
+    let rel_parquet = "tests/data/rels.parquet";
+    create_rel_parquet(rel_parquet).unwrap();
+    load_parquet_relationships_parallel(
+        graph.clone(),
+        rel_parquet,
+        "KNOWS",
+        "Person",
+        "start_name",
+        "Person",
+        "end_name",
+        4,
+    )
+    .await
+    .unwrap();
+    let mut result = graph
+        .execute(neo4rs::query(
+            "MATCH (:Person)-[r:KNOWS]->(:Person) RETURN count(r) as c",
+        ))
+        .await
+        .unwrap();
+    let mut count = 0;
+    while let Ok(Some(row)) = result.next().await {
+        count = row.get::<i64>("c").unwrap();
+    }
+    assert!(count >= 2);
 }


### PR DESCRIPTION
## Summary
- support creating relationships from Parquet rows
- expose new helper from library and document usage
- extend CLI with a `rels` subcommand
- update integration tests for relationship loading

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68697f7330508332abdc5ee25c8d7988