### PR TITLE
Add benchmarking and rename node loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "arrow"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,7 +371,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -422,6 +434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +500,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +536,31 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
@@ -544,6 +614,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1032,6 +1157,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,10 +1392,12 @@ name = "neo4j-parallel-rust-loader"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "criterion",
  "dotenvy",
  "futures",
  "neo4rs",
  "parquet",
+ "rand",
  "tokio",
 ]
 
@@ -1403,6 +1550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1705,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1812,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1789,6 +1990,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2018,6 +2228,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2320,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2422,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ arrow = "55.2"
 
 [dev-dependencies]
 
+criterion = "0.5"
+rand = "0.8"
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ cargo run -- <parquet-file> <node-label> [concurrency]
 
 The application reads the Parquet file and creates nodes with the given label in the database. The optional concurrency argument controls how many rows are inserted in parallel (default is 4).
 
+```rust
+use neo4j_parallel_rust_loader::{connect, load_parquet_nodes_parallel, Neo4jConfig};
+
+let graph = connect(&cfg).await?;
+load_parquet_nodes_parallel(graph, "nodes.parquet", "Person", 8).await?;
+```
+
 ## Loading relationships
 
 The crate also includes a helper to create relationships from Parquet files.

--- a/benches/loader_bench.rs
+++ b/benches/loader_bench.rs
@@ -1,0 +1,54 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use neo4j_parallel_rust_loader::{connect, load_parquet_nodes_parallel, Neo4jConfig};
+use arrow::array::{Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use std::fs::File;
+use std::sync::Arc;
+use std::path::Path;
+
+fn create_nodes_parquet<P: AsRef<Path>>(path: P, rows: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+    let names: Vec<String> = (0..rows).map(|i| format!("N{}", i)).collect();
+    let values: Vec<i64> = (0..rows as i64).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(names)),
+            Arc::new(Int64Array::from(values)),
+        ],
+    )?;
+    let file = File::create(path)?;
+    let mut writer = ArrowWriter::try_new(file, schema, None)?;
+    writer.write(&batch)?;
+    writer.close()?;
+    Ok(())
+}
+
+fn bench_nodes(c: &mut Criterion) {
+    dotenvy::dotenv().ok();
+    let cfg = match Neo4jConfig::from_env() {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let graph = rt.block_on(connect(&cfg)).expect("connect");
+
+    c.bench_function("load 1000 nodes", |b| {
+        b.to_async(&rt).iter(|| async {
+            let parquet = "bench_nodes.parquet";
+            create_nodes_parquet(parquet, 1000).unwrap();
+            load_parquet_nodes_parallel(graph.clone(), parquet, "Bench", 8)
+                .await
+                .unwrap();
+            std::fs::remove_file(parquet).ok();
+        });
+    });
+}
+
+criterion_group!(benches, bench_nodes);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,11 @@ pub mod loader;
 
 pub use config::Neo4jConfig;
 pub use neo4j::connect;
-pub use loader::{load_parquet_parallel, load_parquet_relationships_parallel};
+pub use loader::{
+    load_parquet_nodes_parallel,
+    load_parquet_parallel,
+    load_parquet_relationships_parallel,
+};
 
 #[cfg(test)]
 mod tests {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -10,7 +10,7 @@ use tokio::sync::Semaphore;
 
 /// Load Parquet data into Neo4j in parallel.
 /// Each row in the Parquet file is mapped to properties of a node with the given label.
-pub async fn load_parquet_parallel<P: AsRef<Path>>(
+pub async fn load_parquet_nodes_parallel<P: AsRef<Path>>(
     graph: Graph,
     path: P,
     label: &str,
@@ -54,6 +54,16 @@ pub async fn load_parquet_parallel<P: AsRef<Path>>(
         res??;
     }
     Ok(())
+}
+
+/// Alias kept for backwards compatibility
+pub async fn load_parquet_parallel<P: AsRef<Path>>(
+    graph: Graph,
+    path: P,
+    label: &str,
+    concurrency: usize,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    load_parquet_nodes_parallel(graph, path, label, concurrency).await
 }
 
 /// Load relationships from a Parquet file in parallel.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use neo4j_parallel_rust_loader::{
     connect,
-    load_parquet_parallel,
+    load_parquet_nodes_parallel,
     load_parquet_relationships_parallel,
     Neo4jConfig,
 };
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             .unwrap_or_else(|| "4".to_string())
             .parse()
             .unwrap_or(4);
-        load_parquet_parallel(graph, path, &label, concurrency).await?;
+        load_parquet_nodes_parallel(graph, path, &label, concurrency).await?;
     } else if mode == "rels" {
         let path = match args.next() {
             Some(p) => p,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use neo4j_parallel_rust_loader::{
-    load_parquet_parallel,
+    load_parquet_nodes_parallel,
     load_parquet_relationships_parallel,
     connect,
     Neo4jConfig,
@@ -95,7 +95,7 @@ async fn test_loader() {
     };
     let parquet = "tests/data/sample.parquet";
     create_parquet(parquet).unwrap();
-    load_parquet_parallel(graph.clone(), parquet, "Person", 4).await.unwrap();
+    load_parquet_nodes_parallel(graph.clone(), parquet, "Person", 4).await.unwrap();
     let mut result = graph
         .execute(neo4rs::query("MATCH (n:Person) RETURN count(n) as c"))
         .await
@@ -126,7 +126,7 @@ async fn test_relationship_loader() {
     };
     let parquet = "tests/data/sample.parquet";
     create_parquet(parquet).unwrap();
-    load_parquet_parallel(graph.clone(), parquet, "Person", 4).await.unwrap();
+    load_parquet_nodes_parallel(graph.clone(), parquet, "Person", 4).await.unwrap();
     let rel_parquet = "tests/data/rels.parquet";
     create_rel_parquet(rel_parquet).unwrap();
     load_parquet_relationships_parallel(


### PR DESCRIPTION
## Summary
- rename `load_parquet_parallel` to `load_parquet_nodes_parallel`
- keep old name as an alias
- add Criterion benchmark for loading nodes
- add helper to generate deterministic Parquet data
- document example usage for node loader in README

## Testing
- `cargo test --quiet`
- `cargo check`
- `cargo bench --no-run` *(failed: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6869b725b09483328d936f1b0bb4a3d1