### PR TITLE
Enable Criterion benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ arrow = "55.2"
 # Enable `async_tokio` so Criterion supports `to_async` for Tokio benchmarks
 criterion = { version = "0.5", features = ["async_tokio"] }
 rand = "0.8"
+
+[[bench]]
+name = "loader_bench"
+harness = false


### PR DESCRIPTION
## Summary
- add benchmark configuration to Cargo.toml
- verify benchmark runner

## Testing
- `cargo bench --bench loader_bench --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6869c4261cc8833284dda1db76ab0115