### PR TITLE
Enable Criterion benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,7 @@ dependencies = [
  "neo4rs",
  "parquet",
  "rand",
+ "rustls",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,14 @@ dotenvy = "0.15"
 futures = "0.3"
 parquet = { version = "55.2", features = ["arrow", "json"] }
 arrow = "55.2"
+rustls = { version = "0.23", features = ["ring", "tls12"], default-features = false }
 
 [dev-dependencies]
 
 # Enable `async_tokio` so Criterion supports `to_async` for Tokio benchmarks
 criterion = { version = "0.5", features = ["async_tokio"] }
 rand = "0.8"
+
+[[bench]]
+name = "loader_bench"
+harness = false

--- a/README.md
+++ b/README.md
@@ -54,3 +54,14 @@ load_parquet_relationships_parallel(
 Relationships are colored internally so that each concurrently executed batch
 touches disjoint nodes, greatly reducing lock contention when creating many
 edges at once.
+
+## Running benchmarks
+
+To execute the Criterion benchmarks, ensure the same Neo4j environment variables used for the loader example are set. Then run:
+
+```bash
+cargo bench
+```
+
+The benchmark connects to your database and loads a small Parquet file. When the variables are not present, the benchmark is skipped.
+

--- a/src/neo4j.rs
+++ b/src/neo4j.rs
@@ -1,8 +1,11 @@
 use crate::config::Neo4jConfig;
-use neo4rs::{Graph, ConfigBuilder};
+use neo4rs::{ConfigBuilder, Graph};
+use rustls::crypto::ring;
 
 /// Create a [`Graph`] connection using the provided config.
 pub async fn connect(config: &Neo4jConfig) -> Result<Graph, neo4rs::Error> {
+    // Install the rustls crypto provider so neo4rs can build TLS configs.
+    let _ = ring::default_provider().install_default();
     let mut builder = ConfigBuilder::default()
         .uri(&config.uri)
         .user(&config.username)


### PR DESCRIPTION
## Summary
- add benchmark configuration to `Cargo.toml`
- document how to run the benchmark
- install rustls crypto provider so benches run

## Testing
- `cargo test --quiet`
- `cargo bench --bench loader_bench | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6869c4261cc8833284dda1db76ab0115