### PR TITLE
Reduce Criterion benchmark iterations

### DIFF
--- a/benches/loader_bench.rs
+++ b/benches/loader_bench.rs
@@ -71,5 +71,13 @@ fn bench_nodes(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_nodes);
+use std::time::Duration;
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(5));
+    targets = bench_nodes
+}
 criterion_main!(benches);


### PR DESCRIPTION
## Summary
- limit Criterion sample size to 10 and measurement time to 5s in `loader_bench`

## Testing
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686b05b70c8c8332a5f53f09b060a10c