### PR TITLE
Fix relationship loading logic

### DIFF
--- a/benches/loader_bench.rs
+++ b/benches/loader_bench.rs
@@ -50,7 +50,6 @@ fn create_rels_parquet<P: AsRef<Path>>(
     let batch = RecordBatch::try_new(
         schema.clone(),
         vec![
-
             Arc::new(Int64Array::from(start)),
             Arc::new(Int64Array::from(end)),
             Arc::new(Int64Array::from(since)),
@@ -100,8 +99,10 @@ fn bench_nodes(c: &mut Criterion) {
                 "CONNECTED",
                 "Bench",
                 "start_id",
+                "id",
                 "Bench",
                 "end_id",
+                "id",
                 8,
             )
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,12 @@
 pub mod config;
-pub mod neo4j;
 pub mod loader;
+pub mod neo4j;
 
 pub use config::Neo4jConfig;
-pub use neo4j::connect;
 pub use loader::{
-    load_parquet_nodes_parallel,
-    load_parquet_parallel,
-    load_parquet_relationships_parallel,
+    load_parquet_nodes_parallel, load_parquet_parallel, load_parquet_relationships_parallel,
 };
+pub use neo4j::connect;
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,5 @@
 use neo4j_parallel_rust_loader::{
-    connect,
-    load_parquet_nodes_parallel,
-    load_parquet_relationships_parallel,
-    Neo4jConfig,
+    Neo4jConfig, connect, load_parquet_nodes_parallel, load_parquet_relationships_parallel,
 };
 use std::env;
 
@@ -47,42 +44,54 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let path = match args.next() {
             Some(p) => p,
             None => {
-                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                eprintln!(
+                    "Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+                );
                 std::process::exit(1);
             }
         };
         let rel_type = match args.next() {
             Some(l) => l,
             None => {
-                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                eprintln!(
+                    "Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+                );
                 std::process::exit(1);
             }
         };
         let start_label = match args.next() {
             Some(l) => l,
             None => {
-                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                eprintln!(
+                    "Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+                );
                 std::process::exit(1);
             }
         };
         let start_col = match args.next() {
             Some(c) => c,
             None => {
-                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                eprintln!(
+                    "Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+                );
                 std::process::exit(1);
             }
         };
         let end_label = match args.next() {
             Some(l) => l,
             None => {
-                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                eprintln!(
+                    "Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+                );
                 std::process::exit(1);
             }
         };
         let end_col = match args.next() {
             Some(c) => c,
             None => {
-                eprintln!("Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]");
+                eprintln!(
+                    "Usage: cargo run -- rels <path> <rel-type> <start-label> <start-col> <end-label> <end-col> [concurrency]"
+                );
                 std::process::exit(1);
             }
         };
@@ -97,7 +106,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             &rel_type,
             &start_label,
             &start_col,
+            &start_col,
             &end_label,
+            &end_col,
             &end_col,
             concurrency,
         )


### PR DESCRIPTION
## Summary
- allow mapping relationship ID columns to different node property names
- remove the separate mapped helper and update public API
- adjust benchmark and integration test data to use numeric IDs

## Testing
- `cargo test --all --quiet`
- `cargo bench --bench loader_bench -- --sample-size 10`

------
https://chatgpt.com/codex/tasks/task_e_686b49d5e6688332a5e68a0d571cb7f7